### PR TITLE
Add missing initialization of ri.GL_ExtensionSupported in multiplayer…

### DIFF
--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -2458,6 +2458,7 @@ void CL_InitRef( void ) {
     ri.WIN_Shutdown = WIN_Shutdown;
     ri.WIN_Present = WIN_Present;
 	ri.GL_GetProcAddress = WIN_GL_GetProcAddress;
+	ri.GL_ExtensionSupported = WIN_GL_ExtensionSupported;
 
 	ri.CM_GetCachedMapDiskImage = CM_GetCachedMapDiskImage;
 	ri.CM_SetCachedMapDiskImage = CM_SetCachedMapDiskImage;


### PR DESCRIPTION
Hello,

I just found that "ri.GL_ExtensionSupported" was not initialized in the code of the multiplayer game,
causing it to crash during the initialization.

This pull request fixes this.

Best regards,

Jonathan Pastor